### PR TITLE
Disable doclinker rule for now

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -3,8 +3,7 @@
     "onlyForOrgMembers": false
   },
   "rules": {
-    "issues.opened": "Moya/moya-peril@org/labeler.ts",
-    "issues.labeled": "Moya/moya-peril@moya/doclinker.ts"
+    "issues.opened": "Moya/moya-peril@org/labeler.ts"
   },
   "repos": {
   }


### PR DESCRIPTION
As we had some problems with multiple posts in the issue, and because @SD10 wants to test this before moving forward anyways, we can just disable the rule for now and bring it back later.