### PR TITLE
Excludes bots from being invited after PR merges

### DIFF
--- a/org/aeryn.ts
+++ b/org/aeryn.ts
@@ -28,6 +28,11 @@ export const aeryn = wrap(
       return;
     }
 
+    if (pr.user.type !== "User") {
+      // Ignore PRs from bots.
+      return
+    }
+
     const org = "Moya";
     const inviteMarkdown = `
   @${username} Thanks a lot for contributing to Moya! We've invited you to join 

--- a/tests/aeryn.test.ts
+++ b/tests/aeryn.test.ts
@@ -9,7 +9,8 @@ beforeEach(() => {
     github: {
       pr: {
         user: {
-          login: "a_new_user"
+          login: "a_new_user",
+          type: "User"
         }
       }
     }
@@ -34,6 +35,13 @@ describe("a merged PR", () => {
   beforeEach(() => {
     dm.danger.github.pr.merged = true;
   });
+
+  it("doesn't do anything if the PR was sent by a bot", () => {
+    dm.danger.github.pr.user.type = "Bot"
+    return aeryn().then(() => {
+      expect(dm.markdown).not.toHaveBeenCalled()
+    })
+  })
 
   it("doesn't do anything if the user is a member", () => {
     dm.danger.github.api = {


### PR DESCRIPTION
I noticed that bots, like Depndabot, which sent PRs that got merged had Peril try to invite them to the GitHub organization. This would fail and  leave an error in the GitHub comment. [I applied this fix](https://github.com/ashfurrow/peril-settings/commit/dd009d37d5fae35fafba2b3ca043d32138902baa) to my personal Peril server and wanted to apply the change here as well.